### PR TITLE
feat: add client.folders.getFolder method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 .DS_Store
+.vscode

--- a/src/folders/getFolder.ts
+++ b/src/folders/getFolder.ts
@@ -1,0 +1,35 @@
+import { Get } from "../types";
+
+export interface GetFolderRequestProps {
+  id: string;
+  // TODO: implement QUERY PARAMETERS
+  // sort_by: string;
+  // sort_order: string;
+}
+
+export interface GetFolderResponse {
+  folder: Folder;
+  member_ids: string[];
+  children: { thread_id: string }[];
+}
+
+export interface Folder {
+  title: string;
+  creator_id: string;
+  id: string;
+  created_usec: number;
+  updated_usec: number;
+  // TODO: confirm possible string values (can folder_type be "shared" | "private" ? etc)
+  // folder_type: "shared";
+  // inherit_mode: "inherit";
+  // sharing: {
+  //   company_mode: "EDIT";
+  //   company_id: "LbdAcAwVVIA";
+  // };
+}
+
+// https://quip.com/dev/automation/documentation/current#operation/getFolder
+export const getFolder = (get: Get) => (props: GetFolderRequestProps) => {
+  const { id } = props;
+  return get<GetFolderResponse>(`1/folders/${id}`);
+};

--- a/src/folders/index.test.ts
+++ b/src/folders/index.test.ts
@@ -1,0 +1,17 @@
+import * as folder from ".";
+
+const get = jest.fn();
+// const post = jest.fn();
+
+describe("folder file", () => {
+  const api = new folder.FoldersAPI(get);
+  afterEach(() => {
+    get.mockReset();
+    // post.mockReset();
+  });
+
+  it("has callable getFolder method that uses get", () => {
+    api.getFolder({ id: "" });
+    expect(get).toBeCalledTimes(1);
+  });
+});

--- a/src/folders/index.ts
+++ b/src/folders/index.ts
@@ -1,0 +1,15 @@
+import { Get } from "../types";
+
+import {
+  getFolder,
+  GetFolderRequestProps,
+  GetFolderResponse,
+} from "./getFolder";
+
+export class FoldersAPI {
+  getFolder: (props: GetFolderRequestProps) => Promise<GetFolderResponse>;
+
+  constructor(get: Get) {
+    this.getFolder = getFolder(get);
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,6 +16,7 @@ describe('library', () => {
   it('exports apis', () => {
     expect(client).toHaveProperty('threads');
     expect(client).toHaveProperty('users');
+    expect(client).toHaveProperty('folders');
   });
 
   it('calls axios for GET requests', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,21 @@ import axios from 'axios';
 
 import { EditADocumentLocation, ThreadsAPI } from "./threads";
 import { UsersAPI } from "./users";
+import { FoldersAPI } from './folders';
 
 export class QuipClient {
   threads: ThreadsAPI;
   users: UsersAPI;
+  folders: FoldersAPI;
 
   constructor(accessToken: string, urlBase = 'https://platform.quip.com/') {
     const axiosConfig = { headers: { Authorization: 'Bearer ' + accessToken } };
     const get = <T>(path: string) => axios.get<T>(urlBase + path, axiosConfig).then(response => response.data);
     const post = <T>(path: string, data: any) => axios.post<T>(urlBase + path, data, axiosConfig).then(response => response.data);
-    
+
     this.threads = new ThreadsAPI(get, post);
     this.users = new UsersAPI(get);
+    this.folders = new FoldersAPI(get);
   }
 }
 


### PR DESCRIPTION
Just started using this and love it. I need to [get a folder](https://quip.com/dev/automation/documentation/current#operation/getFolder) in the project I'm working on though, so I was hoping to extend the library to include this functionality. Let me know if I should tweak anything!