### PR TITLE
feat: add client.threads.getThreadV2 method

### DIFF
--- a/src/threads/getThreadV2.ts
+++ b/src/threads/getThreadV2.ts
@@ -1,0 +1,18 @@
+
+import { Get, ResponseMetadata } from "../types";
+import { Thread } from ".";
+
+export interface GetThreadV2RequestProps {
+  id: string;
+}
+
+export interface GetThreadV2Response {
+  thread: Thread
+}
+
+// https://quip.com/dev/automation/documentation/current#operation/getThreadV2
+export const getThreadV2 = (get: Get) => (props: GetThreadV2RequestProps) => {
+  const { id } = props;
+
+  return get<GetThreadV2Response>(`2/threads/${id}`);
+}

--- a/src/threads/index.test.ts
+++ b/src/threads/index.test.ts
@@ -40,4 +40,9 @@ describe('threads file', () => {
     expect(get).toBeCalledTimes(1);
   });
 
+  it('has callable getThreadV2 method that uses get', () => {
+    api.getThreadV2({ id: '' });
+    expect(get).toBeCalledTimes(1);
+  });
+
 });

--- a/src/threads/index.ts
+++ b/src/threads/index.ts
@@ -6,6 +6,7 @@ import { createADocumentOrSpreadsheet, CreateADocumentOrSpreadsheetRequestProps,
 import { editADocument, EditADocumentLocation, EditADocumentRequestProps, EditADocumentResponse } from "./editADocument";
 import { getThreadHtmlV2, GetThreadHtmlV2RequestProps, GetThreadHtmlV2Response } from "./getThreadHtmlV2";
 import { getThreadMembersV2, GetThreadMembersV2RequestProps, GetThreadMembersV2Response } from "./getThreadMembersV2";
+import { getThreadV2, GetThreadV2RequestProps, GetThreadV2Response } from "./getThreadV2";
 
 export class ThreadsAPI {
   /** [Quip API Reference](https://quip.com/dev/automation/documentation/current#operation/addMembersToThreadOrAddThreadToFolders) */
@@ -26,6 +27,9 @@ export class ThreadsAPI {
   /** [Quip API Reference](https://quip.com/dev/automation/documentation/current#operation/getThreadMembersV2) */
   getThreadMembersV2: (props: GetThreadMembersV2RequestProps) => Promise<GetThreadMembersV2Response>;
 
+  /** [Quip API Reference](https://quip.com/dev/automation/documentation/current#operation/getThreadV2) */
+  getThreadV2: (props: GetThreadV2RequestProps) => Promise<GetThreadV2Response>;
+
   /** @internal */
   constructor(get: Get, post: Post) {
     this.addMembersToThreadOrAddThreadToFolders = addMembersToThreadOrAddThreadToFolders(post);
@@ -34,6 +38,7 @@ export class ThreadsAPI {
     this.editADocument = editADocument(post);
     this.getThreadHtmlV2 = getThreadHtmlV2(get);
     this.getThreadMembersV2 = getThreadMembersV2(get);
+    this.getThreadV2 = getThreadV2(get);
   }
 }
 


### PR DESCRIPTION
Thanks for merging my last PR! Hoping to add one more method, this time to support getting the metadata of a Thread via [getThreadV2](https://quip.com/dev/automation/documentation/current#operation/getThreadV2). Let me know if I should tweak anything!